### PR TITLE
Require URL to ETS file to be provided as a parameter

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Los Angeles Times Data Desk
+Copyright (c) 2019 Los Angeles Times Data Desk
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # la-election-night
 
-Parse the results file published on election night by the Los Angeles County Registrar-Recorder/County Clerk
+Parse historical and election night result files published by the [Los Angeles County Registrar-Recorder/County Clerk](http://rrcc.co.la.ca.us/elect/downrslt.html-ssi).
 
-### Get started
+## Get started
 
 Install the library from PyPI
 
@@ -10,11 +10,11 @@ Install the library from PyPI
 $ pipenv install la-election-night
 ```
 
-Import the library. Get the latest data from the live URL. That's it.
+Import the library. Get the latest data from the URL you provide. That's it.
 
 ```python
 >>> import la_election_night
->>> la_election_night.get()
+>>> la_election_night.get('http://rrcc.co.la.ca.us/results/0018nov18.ets')
 [
     {
         "record_number": "001",
@@ -42,3 +42,7 @@ Import the library. Get the latest data from the live URL. That's it.
 ```
 
 You can example of how the data is parsed out can be seen [here](test_data/0018nov18-end.json).
+
+## License
+
+MIT

--- a/la_election_night/__init__.py
+++ b/la_election_night/__init__.py
@@ -2,12 +2,11 @@ import requests
 from .ets import ETSParser
 
 
-def get():
+def get(ets_url):
     """
-    Get the latest results from the LA County ETS data service.
+    Get the results from the LA County ETS source available at the provided URL.
     """
-    url = "http://rrcc.co.la.ca.us/results/0018nov18.ets"
-    r = requests.get(url)
+    r = requests.get(ets_url)
     raw_data = r.text
     parser = ETSParser(raw_data)
     return parser.run()

--- a/tests.py
+++ b/tests.py
@@ -15,7 +15,7 @@ class LAElectionsTest(unittest.TestCase):
     ets_files = glob.glob("{}/*.ets".format(data_dir))
 
     def test_get(self):
-        la_election_night.get()
+        la_election_night.get('http://rrcc.co.la.ca.us/results/0018nov18.ets')
 
     def test_ets(self):
         for ets in self.ets_files:


### PR DESCRIPTION
This change will make it a requirement to pass in the URL of an ETS file from the [Los Angeles County Clerk Election Results site](http://rrcc.co.la.ca.us/elect/downrslt.html-ssi). Currently a results URL is hard-coded into the library. I adjusted the tests so they continue to pass with this change.

I also bumped the year in the LICENSE file to 2019.